### PR TITLE
fix: correct unsafe HTTPS flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The following environment variables influence Localize behaviour.
 |----------|-------------|
 | `LOCALIZE_DEFAULT_LOCALE` | Sets the application-wide default locale (e.g., `en-AU`, `ja`). Takes precedence over the `LANG` variable and the `:default_locale` application config. Evaluated once on first call to `Localize.get_locale/0` or `Localize.default_locale/0`. |
 | `LANG` | Standard POSIX locale variable (e.g., `en_US.UTF-8`). Used as a fallback when `LOCALIZE_DEFAULT_LOCALE` is not set and no `:default_locale` is configured. The value is converted from POSIX format (underscores replaced with hyphens, encoding suffix stripped). |
-| `LOCALIZE_UNSAFE_HTTPS` | When set to any value, disables SSL certificate verification for HTTPS connections (e.g., locale data downloads). Intended for development behind corporate proxies with self-signed certificates. Do not use in production. |
+| `LOCALIZE_UNSAFE_HTTPS` | When set to a truthy value, disables SSL certificate verification for HTTPS connections (e.g., locale data downloads). Intended for development behind corporate proxies with self-signed certificates. Do not use in production. |
 | `LOCALIZE_HTTP_TIMEOUT` | HTTP request timeout in milliseconds for locale data downloads. Overrides the default timeout. |
 | `LOCALIZE_HTTP_CONNECTION_TIMEOUT` | HTTP connection timeout in milliseconds for locale data downloads. Overrides the default connection timeout. |
 | `HTTPS_PROXY` / `https_proxy` | HTTPS proxy URL for outbound connections. Also configurable via the `:https_proxy` application config key. |

--- a/lib/localize/utils/http.ex
+++ b/lib/localize/utils/http.ex
@@ -460,14 +460,16 @@ defmodule Localize.Utils.Http do
     :ssl.eccs() -- (:ssl.eccs() -- preferred_eccs)
   end
 
-  defp secure_ssl? do
-    case System.get_env(@localize_unsafe_https) do
+  @doc false
+  @spec secure_ssl?(String.t() | nil) :: boolean()
+  def secure_ssl?(unsafe_https \\ System.get_env(@localize_unsafe_https)) do
+    case unsafe_https do
       nil -> true
-      "FALSE" -> false
-      "false" -> false
-      "nil" -> false
-      "NIL" -> false
-      _other -> true
+      "FALSE" -> true
+      "false" -> true
+      "nil" -> true
+      "NIL" -> true
+      _other -> false
     end
   end
 

--- a/test/localize/utils/http_test.exs
+++ b/test/localize/utils/http_test.exs
@@ -1,5 +1,25 @@
 defmodule Localize.Utils.HttpTest do
+  @moduledoc """
+  Covers HTTP utility helpers that can be tested without opening network
+  connections.
+
+  These tests do not exercise the Erlang httpc transport or external
+  certificate stores.
+  """
+
   use ExUnit.Case, async: true
 
   doctest Localize.Utils.Http
+
+  describe "secure_ssl?/1" do
+    test "keeps verification enabled when unsafe HTTPS is unset or explicitly false" do
+      assert Localize.Utils.Http.secure_ssl?(nil)
+      assert Localize.Utils.Http.secure_ssl?("false")
+      assert Localize.Utils.Http.secure_ssl?("NIL")
+    end
+
+    test "disables verification when unsafe HTTPS is set to a truthy value" do
+      refute Localize.Utils.Http.secure_ssl?("true")
+    end
+  end
 end


### PR DESCRIPTION
## Why

`LOCALIZE_UNSAFE_HTTPS` is documented as the switch that disables HTTPS certificate verification. The implementation had the useful cases backwards: values such as `true` kept verification enabled, while `false` and `nil` disabled it.

That makes `LOCALIZE_UNSAFE_HTTPS=false` unsafe, even though it reads like the opt-out value. It also means setting the variable to a normal truthy value does not do what the documentation says.

## What Changed

`secure_ssl?/1` now treats unset, `false`, and `nil` values as secure, and treats any other configured value as the explicit unsafe opt-in.

The README now says "truthy value" instead of "any value", which matches the safer env-var contract.