### PR TITLE
fix: honor locale provider options

### DIFF
--- a/lib/localize/locale.ex
+++ b/lib/localize/locale.ex
@@ -354,7 +354,7 @@ defmodule Localize.Locale do
           {:ok, map()} | {:error, Exception.t()}
   def load(locale, options \\ []) do
     {provider, _options} = Keyword.pop(options, :provider, default_provider())
-    provider.store(locale, locale)
+    provider.load(locale)
   end
 
   @doc """
@@ -488,7 +488,7 @@ defmodule Localize.Locale do
   def get(locale, keys, options \\ []) do
     {provider, options} = Keyword.pop(options, :provider, default_provider())
 
-    case load_and_store(locale) do
+    case load_and_store(locale, provider: provider) do
       :ok -> provider.get(locale, keys, options)
       {:error, _} = error -> error
     end

--- a/test/localize/locale/provider_delegation_test.exs
+++ b/test/localize/locale/provider_delegation_test.exs
@@ -1,0 +1,91 @@
+defmodule Localize.Locale.ProviderDelegationTest do
+  @moduledoc """
+  Covers `Localize.Locale` delegation to caller-selected providers.
+
+  These tests use fake providers to observe delegation. They do not
+  exercise the default persistent-term provider.
+  """
+
+  use ExUnit.Case, async: true
+
+  defmodule LoadOnlyProvider do
+    @moduledoc false
+    @behaviour Localize.Locale.Provider
+
+    def load(locale), do: {:ok, %{loaded_locale: locale}}
+    def store(_locale, _data), do: raise("Localize.Locale.load/2 must not call store/2")
+    def loaded?(_locale), do: false
+    def get(_locale, _keys, _options), do: {:error, :not_used}
+  end
+
+  defmodule RecordingProvider do
+    @moduledoc false
+    @behaviour Localize.Locale.Provider
+
+    def table, do: __MODULE__
+
+    def register(locale, pid), do: :ets.insert(table(), {locale, pid})
+    def unregister(locale), do: :ets.delete(table(), locale)
+
+    def load(locale) do
+      notify(locale, {:provider_load, locale})
+      {:ok, %{loaded_locale: locale}}
+    end
+
+    def store(locale, data) do
+      notify(locale, {:provider_store, locale, data})
+      :ok
+    end
+
+    def loaded?(_locale), do: false
+
+    def get(locale, keys, _options) do
+      notify(locale, {:provider_get, locale, keys})
+      {:ok, %{get_locale: locale, keys: keys}}
+    end
+
+    defp notify(locale, message) do
+      case :ets.lookup(table(), locale) do
+        [{^locale, pid}] -> send(pid, message)
+        [] -> :ok
+      end
+    end
+  end
+
+  setup_all do
+    table = RecordingProvider.table()
+
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+
+    :ets.new(table, [:named_table, :public])
+
+    on_exit(fn ->
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end)
+
+    :ok
+  end
+
+  test "Localize.Locale.load/2 delegates to provider load/1" do
+    assert {:ok, %{loaded_locale: :en}} =
+             Localize.Locale.load(:en, provider: LoadOnlyProvider)
+  end
+
+  test "Localize.Locale.get/3 loads through the requested provider" do
+    RecordingProvider.register(:en, self())
+
+    on_exit(fn -> RecordingProvider.unregister(:en) end)
+
+    assert {:ok, result} =
+             Localize.Locale.get(:en, [:delimiters], provider: RecordingProvider)
+
+    assert_receive {:provider_load, :en}
+    assert_receive {:provider_store, :en, %{loaded_locale: :en}}
+    assert_receive {:provider_get, :en, [:delimiters]}
+    assert result == %{get_locale: :en, keys: [:delimiters]}
+  end
+end


### PR DESCRIPTION
## Why

`Localize.Locale` lets callers pass `provider: MyProvider` to use a custom locale data provider. Two code paths broke that contract.

`Localize.Locale.load/2` selected the provider, but then called `provider.store(locale, locale)` instead of `provider.load(locale)`. That means `load/2` did not load data at all; it tried to store the locale id as if it were locale data.

`Localize.Locale.get/3` selected the provider for `provider.get/3`, but loaded data through `load_and_store(locale)` without passing the provider. That made loading happen through the default provider, while the read happened through the requested provider.

The default provider can hide this in normal usage, but custom providers see inconsistent behaviour: the wrong provider is loaded, or the requested provider is read before it has been loaded.

## What Changed

`load/2` now delegates to the selected provider with `provider.load(locale)`.

`get/3` now passes the selected provider into `load_and_store/2`, so loading and reading use the same provider.