### PR TITLE
fix: honor persistent-term fallback option

### DIFF
--- a/lib/localize/locale/provider/persistent_term.ex
+++ b/lib/localize/locale/provider/persistent_term.ex
@@ -177,19 +177,82 @@ defmodule Localize.Locale.Provider.PersistentTerm do
 
   """
   @impl Localize.Locale.Provider
-  def get(locale, keys, _options \\ []) when is_list(keys) do
+  def get(locale, keys, options \\ []) when is_list(keys) do
     locale_id = to_locale_id(locale)
-    locale_key = locale_key(locale_id)
-    locale_data = :persistent_term.get(locale_key)
 
-    if item = get_in(locale_data, keys) do
-      {:ok, item}
-    else
-      {:error, Localize.ItemNotFoundError.exception(locale: locale_id, keys: keys)}
+    case fetch(locale_id, keys) do
+      {:ok, item} ->
+        {:ok, item}
+
+      :error ->
+        if Keyword.get(options, :fallback, false) do
+          get_from_parent(locale_id, keys)
+        else
+          not_found(locale_id, keys)
+        end
     end
   end
 
   # ── Helpers ──────────────────────────────────────────────────
+
+  defp fetch(locale_id, keys) do
+    case :persistent_term.get(locale_key(locale_id), :localize_locale_not_loaded) do
+      :localize_locale_not_loaded ->
+        :error
+
+      locale_data ->
+        if item = get_in(locale_data, keys) do
+          {:ok, item}
+        else
+          :error
+        end
+    end
+  end
+
+  defp get_from_parent(locale_id, keys) do
+    get_from_parent(locale_id, locale_id, keys, MapSet.new([locale_id]))
+  end
+
+  defp get_from_parent(original_locale_id, current_locale_id, keys, visited) do
+    case next_parent(current_locale_id, visited) do
+      {:ok, parent_id} ->
+        case load_and_fetch(parent_id, keys) do
+          {:ok, item} ->
+            {:ok, item}
+
+          :error ->
+            get_from_parent(original_locale_id, parent_id, keys, MapSet.put(visited, parent_id))
+        end
+
+      :error ->
+        not_found(original_locale_id, keys)
+    end
+  end
+
+  defp next_parent(locale_id, visited) do
+    case Localize.Locale.parent(to_string(locale_id)) do
+      {:ok, parent_tag} ->
+        parent_id = to_locale_id(parent_tag)
+
+        if MapSet.member?(visited, parent_id) do
+          :error
+        else
+          {:ok, parent_id}
+        end
+
+      {:error, _} ->
+        :error
+    end
+  end
+
+  defp load_and_fetch(locale_id, keys) do
+    _ = Localize.Locale.load_and_store(locale_id, provider: __MODULE__)
+    fetch(locale_id, keys)
+  end
+
+  defp not_found(locale_id, keys) do
+    {:error, Localize.ItemNotFoundError.exception(locale: locale_id, keys: keys)}
+  end
 
   defp to_locale_id(locale) do
     Localize.Locale.to_locale_id(locale)

--- a/test/localize/locale/persistent_term_test.exs
+++ b/test/localize/locale/persistent_term_test.exs
@@ -1,0 +1,50 @@
+defmodule Localize.Locale.PersistentTermTest do
+  @moduledoc """
+  Covers persistent-term locale provider lookup behaviour.
+
+  These tests use generated locale data loaded through the normal locale
+  loading path. They do not cover cache freshness, runtime downloads, or
+  alternative locale providers.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Localize.Locale
+
+  @parent_only_key [:dates, :calendars, :gregorian, :available_formats, :yMMdd]
+  @grandparent_only_key [:subdivisions, :twcyi]
+  @locale_specific_key [:territories, :TC, :standard]
+  @missing_key [:localize_test, :missing_key]
+
+  describe "get/3" do
+    test "does not search parent locales by default" do
+      assert {:error, %Localize.ItemNotFoundError{locale: :"en-AU", keys: @parent_only_key}} =
+               Locale.get(:"en-AU", @parent_only_key)
+    end
+
+    test "does not search parent locales when fallback is false" do
+      assert {:error, %Localize.ItemNotFoundError{locale: :"en-AU", keys: @parent_only_key}} =
+               Locale.get(:"en-AU", @parent_only_key, fallback: false)
+    end
+
+    test "searches the immediate parent locale when fallback is enabled" do
+      assert {:ok, "dd/MM/y"} =
+               Locale.get(:"en-AU", @parent_only_key, fallback: true)
+    end
+
+    test "uses the requested locale before searching parents" do
+      assert {:ok, "Turks and Caicos Islands"} =
+               Locale.get(:"en-AU", @locale_specific_key, fallback: true)
+    end
+
+    test "continues past the immediate parent locale" do
+      assert {:ok, "Chiayi County"} =
+               Locale.get(:"en-AU", @grandparent_only_key, fallback: true)
+    end
+
+    test "keeps not-found errors tied to the requested locale" do
+      assert {:error, %Localize.ItemNotFoundError{locale: :"en-AU", keys: @missing_key}} =
+               Locale.get(:"en-AU", @missing_key, fallback: true)
+    end
+  end
+end


### PR DESCRIPTION
## Why

`Localize.Locale.get/3` and the provider behaviour both document `fallback: true`: when a key is missing in the requested locale, the provider should look through the CLDR parent locale chain.

`Localize.Locale.Provider.PersistentTerm.get/3` accepted options, but ignored them. That means a real inherited lookup such as `en-AU` asking for `[:dates, :calendars, :gregorian, :available_formats, :yMMdd]` returned `ItemNotFoundError`, even though the parent locale `en-001` has the value `"dd/MM/y"`.

## What Changed

The persistent-term provider now honors `fallback: true` by walking parent locales with `Localize.Locale.parent/1`, loading each parent if needed, and checking the requested key path there.

The tests cover default lookup, explicit `fallback: false`, immediate-parent fallback, multi-hop fallback, requested-locale precedence, and the error locale returned when the fallback chain is exhausted.

If the fallback chain is exhausted, the not-found error stays tied to the original requested locale instead of the last parent checked.