### PR TITLE
fix: resolve raw language tags in formatters

### DIFF
--- a/lib/localize/date.ex
+++ b/lib/localize/date.ex
@@ -240,6 +240,13 @@ defmodule Localize.Date do
 
   # ── Locale resolution ──────────────────────────────────────
 
+  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: nil} = locale) do
+    case Localize.validate_locale(locale) do
+      {:ok, tag} -> {:ok, tag.cldr_locale_id}
+      error -> error
+    end
+  end
+
   defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: id}), do: {:ok, id}
 
   defp resolve_locale_id(locale) when is_atom(locale) or is_binary(locale) do

--- a/lib/localize/datetime.ex
+++ b/lib/localize/datetime.ex
@@ -339,6 +339,13 @@ defmodule Localize.DateTime do
     end
   end
 
+  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: nil} = locale) do
+    case Localize.validate_locale(locale) do
+      {:ok, tag} -> {:ok, tag.cldr_locale_id}
+      error -> error
+    end
+  end
+
   defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: id}), do: {:ok, id}
 
   defp resolve_locale_id(locale) when is_atom(locale) or is_binary(locale) do

--- a/lib/localize/datetime/relative.ex
+++ b/lib/localize/datetime/relative.ex
@@ -272,6 +272,13 @@ defmodule Localize.DateTime.Relative do
      )}
   end
 
+  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: nil} = locale) do
+    case Localize.validate_locale(locale) do
+      {:ok, tag} -> {:ok, tag.cldr_locale_id}
+      error -> error
+    end
+  end
+
   defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: id}), do: {:ok, id}
 
   defp resolve_locale_id(locale) when is_atom(locale) or is_binary(locale) do

--- a/lib/localize/interval.ex
+++ b/lib/localize/interval.ex
@@ -584,6 +584,13 @@ defmodule Localize.Interval do
 
   # ── Locale resolution ──────────────────────────────────────
 
+  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: nil} = locale) do
+    case Localize.validate_locale(locale) do
+      {:ok, tag} -> {:ok, tag.cldr_locale_id}
+      error -> error
+    end
+  end
+
   defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: id}), do: {:ok, id}
 
   defp resolve_locale_id(locale) when is_atom(locale) or is_binary(locale) do

--- a/lib/localize/list.ex
+++ b/lib/localize/list.ex
@@ -409,13 +409,21 @@ defmodule Localize.List do
   # locale resolver and avoids the `String.to_existing_atom/1`
   # pitfall where a locale string like `"en-US"` may not yet
   # have been interned as an atom.
-  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: id}) when not is_nil(id) do
+  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: nil} = locale) do
+    case Localize.validate_locale(locale) do
+      {:ok, %Localize.LanguageTag{cldr_locale_id: id}} -> {:ok, id}
+      error -> error
+    end
+  end
+
+  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: id}) do
     {:ok, id}
   end
 
   defp resolve_locale_id(locale) when is_atom(locale) or is_binary(locale) do
-    with {:ok, %Localize.LanguageTag{cldr_locale_id: id}} <- Localize.validate_locale(locale) do
-      {:ok, id}
+    case Localize.validate_locale(locale) do
+      {:ok, %Localize.LanguageTag{cldr_locale_id: id}} -> {:ok, id}
+      error -> error
     end
   end
 

--- a/lib/localize/time.ex
+++ b/lib/localize/time.ex
@@ -217,6 +217,13 @@ defmodule Localize.Time do
 
   # ── Locale resolution ──────────────────────────────────────
 
+  defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: nil} = locale) do
+    case Localize.validate_locale(locale) do
+      {:ok, tag} -> {:ok, tag.cldr_locale_id}
+      error -> error
+    end
+  end
+
   defp resolve_locale_id(%Localize.LanguageTag{cldr_locale_id: id}), do: {:ok, id}
 
   defp resolve_locale_id(locale) when is_atom(locale) or is_binary(locale) do

--- a/test/localize/raw_language_tag_resolution_test.exs
+++ b/test/localize/raw_language_tag_resolution_test.exs
@@ -1,0 +1,33 @@
+defmodule Localize.RawLanguageTagResolutionTest do
+  @moduledoc """
+  Covers public formatting APIs when passed a raw parsed language tag.
+
+  The test verifies locale resolution across representative date, time,
+  interval, relative-time, and list APIs. It does not cover every locale
+  or formatting option.
+  """
+
+  use ExUnit.Case, async: true
+
+  test "formatting APIs resolve parsed tags whose CLDR locale is not populated" do
+    {:ok, raw_fr} = Localize.LanguageTag.parse("fr")
+
+    assert raw_fr.cldr_locale_id == nil
+    assert {:ok, "22 mars 2025"} = Localize.Date.to_string(~D[2025-03-22], locale: raw_fr)
+    assert {:ok, "14:30:00"} = Localize.Time.to_string(~T[14:30:00], locale: raw_fr)
+
+    assert {:ok, "22 mars 2025, 14:30:00"} =
+             Localize.DateTime.to_string(~N[2025-03-22 14:30:00], locale: raw_fr)
+
+    assert {:ok, interval} =
+             Localize.Interval.to_string(~D[2025-03-20], ~D[2025-03-22], locale: raw_fr)
+
+    assert String.contains?(interval, "20")
+    assert String.contains?(interval, "22 mars 2025")
+
+    assert {:ok, "hier"} =
+             Localize.DateTime.Relative.to_string(-1, unit: :day, locale: raw_fr)
+
+    assert {:ok, "a, b et c"} = Localize.List.to_string(["a", "b", "c"], locale: raw_fr)
+  end
+end


### PR DESCRIPTION
## Why

`Localize.LanguageTag.parse/1` returns a valid `%Localize.LanguageTag{}` without a populated `cldr_locale_id`. Several formatter APIs accepted that struct but used the nil field as the locale ID, which made locale data lookup fail even though the tag itself was valid.

## What Changed

Date, time, datetime, interval, relative-time, and list formatting now handle parsed language tags explicitly.

When a tag already has a CLDR locale ID, the formatter uses it directly. When `cldr_locale_id` is `nil`, the formatter resolves the tag through `Localize.validate_locale/1` first and then uses the populated CLDR locale ID.

This keeps invalid locale handling on the existing `{:error, exception}` path instead of silently coercing invalid input into an atom.