### PR TITLE
fix: avoid atom creation in string validators

### DIFF
--- a/lib/localize.ex
+++ b/lib/localize.ex
@@ -847,7 +847,7 @@ defmodule Localize do
   end
 
   def available_locale_id?(locale_name) when is_binary(locale_name) do
-    available_locale_id?(String.to_atom(locale_name))
+    Enum.any?(all_locale_ids(), &(Atom.to_string(&1) == locale_name))
   end
 
   @doc """
@@ -1031,9 +1031,7 @@ defmodule Localize do
   @spec validate_calendar(atom() | String.t()) ::
           {:ok, atom()} | {:error, Exception.t()}
   def validate_calendar(calendar) when is_binary(calendar) do
-    normalised = normalize_calendar(calendar)
-
-    if normalised in known_calendars() do
+    if normalised = normalize_calendar(calendar) do
       {:ok, normalised}
     else
       {:error, Localize.UnknownCalendarError.exception(calendar: calendar)}
@@ -1041,9 +1039,7 @@ defmodule Localize do
   end
 
   def validate_calendar(calendar) when is_atom(calendar) do
-    normalised = calendar |> Atom.to_string() |> normalize_calendar()
-
-    if normalised in known_calendars() do
+    if normalised = calendar |> Atom.to_string() |> normalize_calendar() do
       {:ok, normalised}
     else
       {:error, Localize.UnknownCalendarError.exception(calendar: calendar)}
@@ -1052,15 +1048,20 @@ defmodule Localize do
 
   # BCP 47 short-form aliases that don't match the underscore form of
   # the canonical CLDR identifier.
-  defp normalize_calendar("gregory"), do: :gregorian
-  defp normalize_calendar("ethioaa"), do: :ethiopic_amete_alem
-  defp normalize_calendar("islamicc"), do: :islamic_civil
-
   defp normalize_calendar(name) when is_binary(name) do
-    name
-    |> String.downcase()
-    |> String.replace("-", "_")
-    |> String.to_atom()
+    normalised =
+      name
+      |> String.downcase()
+      |> String.replace("-", "_")
+
+    aliases = %{
+      "gregory" => :gregorian,
+      "ethioaa" => :ethiopic_amete_alem,
+      "islamicc" => :islamic_civil
+    }
+
+    Map.get(aliases, normalised) ||
+      Enum.find(known_calendars(), &(Atom.to_string(&1) == normalised))
   end
 
   @doc """
@@ -1095,7 +1096,13 @@ defmodule Localize do
   @spec validate_number_system(atom() | String.t()) ::
           {:ok, atom()} | {:error, Exception.t()}
   def validate_number_system(number_system) when is_binary(number_system) do
-    validate_number_system(String.to_atom(number_system))
+    case Enum.find(known_number_systems(), &(Atom.to_string(&1) == number_system)) do
+      nil ->
+        {:error, Localize.UnknownNumberSystemError.exception(number_system: number_system)}
+
+      number_system ->
+        {:ok, number_system}
+    end
   end
 
   def validate_number_system(number_system) when is_atom(number_system) do

--- a/test/localize/atom_safe_validation_test.exs
+++ b/test/localize/atom_safe_validation_test.exs
@@ -1,0 +1,51 @@
+defmodule Localize.AtomSafeValidationTest do
+  @moduledoc """
+  Covers public validation paths that accept caller-provided strings.
+
+  These tests assert that unknown inputs are rejected without interning
+  new atoms. They do not cover language tag parsing or permissive locale
+  best matching.
+  """
+
+  use ExUnit.Case, async: true
+
+  describe "calendar, number system, and locale availability validation" do
+    test "known string inputs still resolve" do
+      assert Localize.available_locale_id?("en")
+      assert {:ok, :persian} = Localize.validate_calendar("persian")
+      assert {:ok, :islamic_umalqura} = Localize.validate_calendar("islamic-umalqura")
+      assert {:ok, :ethiopic_amete_alem} = Localize.validate_calendar("ethioaa")
+      assert {:ok, :latn} = Localize.validate_number_system("latn")
+    end
+
+    test "unknown strings do not become atoms" do
+      suffix = System.unique_integer([:positive])
+      unknown_calendar = "localize_atom_safe_calendar_#{suffix}"
+      unknown_number_system = "localizeatomsafenumbersystem#{suffix}"
+      unknown_locale = "localize-atom-safe-locale-#{suffix}"
+
+      refute existing_atom?(unknown_calendar)
+      refute existing_atom?(unknown_number_system)
+      refute existing_atom?(unknown_locale)
+
+      assert {:error, %Localize.UnknownCalendarError{}} =
+               Localize.validate_calendar(unknown_calendar)
+
+      assert {:error, %Localize.UnknownNumberSystemError{}} =
+               Localize.validate_number_system(unknown_number_system)
+
+      refute Localize.available_locale_id?(unknown_locale)
+
+      refute existing_atom?(unknown_calendar)
+      refute existing_atom?(unknown_number_system)
+      refute existing_atom?(unknown_locale)
+    end
+  end
+
+  defp existing_atom?(value) do
+    _ = String.to_existing_atom(value)
+    true
+  rescue
+    ArgumentError -> false
+  end
+end


### PR DESCRIPTION
## Why

`available_locale_id?/1`, `validate_calendar/1`, and `validate_number_system/1` all accept strings.

Before this change, those string paths used `String.to_atom/1` before checking whether the value was known. That means rejected values could still create new atoms first:

- `available_locale_id?(unknown)` returned `false` after interning `unknown`.
- `validate_calendar(unknown)` returned `{:error, ...}` after interning the normalized calendar name.
- `validate_number_system(unknown)` returned `{:error, ...}` after interning the number-system name.

## What Changed

String inputs are now checked against the known CLDR atoms by comparing strings. The code only returns an atom after it has matched an existing locale ID, calendar ID, or number system.

Known values keep the same behavior. Calendar aliases like `"gregory"`, `"ethioaa"`, and `"islamicc"` still resolve to their canonical calendar atoms.

We leave `LanguageTag.Parser` and `validate_locale/1` alone.