### PR TITLE
Fix stand-alone pattern helpers passing wrong option to Calendar.localize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+* `Localize.DateTime.Formatter` stand-alone pattern helpers (`standalone_day_of_week/4`, `standalone_month/4`, `standalone_quarter/4`) now pass `context: :stand_alone` to `Localize.Calendar.localize/3` instead of an invalid `type:` option. Lowercase LDML pattern letters `c`, `L`, and `q` therefore resolve to CLDR stand-alone data where it differs from format context (e.g. German `ccc` vs `EEE`).
+
 ## [0.23.0] — April 25th, 2026
 
 ### Bug Fixes

--- a/lib/localize/datetime/formatter.ex
+++ b/lib/localize/datetime/formatter.ex
@@ -205,7 +205,7 @@ defmodule Localize.DateTime.Formatter do
 
     Localize.Calendar.localize(date, :quarter,
       locale: locale_id,
-      type: :stand_alone,
+      context: :stand_alone,
       format: format
     )
   end
@@ -238,7 +238,7 @@ defmodule Localize.DateTime.Formatter do
 
     Localize.Calendar.localize(date, :month,
       locale: locale_id,
-      type: :stand_alone,
+      context: :stand_alone,
       format: format
     )
   end
@@ -349,7 +349,7 @@ defmodule Localize.DateTime.Formatter do
 
     Localize.Calendar.localize(date, :day_of_week,
       locale: locale_id,
-      type: :stand_alone,
+      context: :stand_alone,
       format: format
     )
   end


### PR DESCRIPTION
I noticed a bug in how (at least) german weekday names were formatted getting a "Sa." instead of "Sa" for "Samstag" (so with an added period). Looks like this fixes this:

`standalone_day_of_week/4`, `standalone_month/4`, and `standalone_quarter/4` called `Localize.Calendar.localize/3` with `type: :stand_alone`, but the public API expects **`context:`** (default **`:format`**). Unknown keywords were ignored, so lowercase LDML pattern letters **`c`**, **`L`**, and **`q`** resolved **format-context** data instead of **stand-alone** data.

Disclaimer: an AI agent used to track this down.