### PR TITLE
Allow Decimal 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -202,7 +202,7 @@ defmodule Localize.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:decimal, "~> 2.0"},
+      {:decimal, "~> 2.0 or ~> 3.0"},
       {:gettext, "~> 1.0"},
       {:ex_doc, "~> 0.18", only: [:dev, :release]},
       {:nimble_parsec, "~> 1.0", runtime: false},


### PR DESCRIPTION
There's a [CVE](https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v) that's fixed in Decimal 3.0 and the breaking changes don't seem to impact the usage in `localize`, so I've added allowing 3.0 alongside 2.0.