### PR TITLE
Add fallback option to Currency.currency_for_code/2

### DIFF
--- a/lib/localize/currency.ex
+++ b/lib/localize/currency.ex
@@ -504,28 +504,104 @@ defmodule Localize.Currency do
   ### Options
 
   * `:locale` is a locale identifier atom or a
-    `t:Localize.LanguageTag.t/0`. The default is `:en`.
+    `t:Localize.LanguageTag.t/0`. The default is the current
+    process locale (see `Localize.get_locale/0`).
+
+  * `:fallback` is a boolean. When `true`, if the currency has
+    no entry in the requested locale's currency map, the CLDR
+    parent locale chain is walked, followed by the application
+    default locale (`Localize.default_locale/0`), looking for
+    localized data. The default is `false`.
 
   ### Returns
 
   * `{:ok, Localize.Currency.t()}` with localized currency metadata.
 
-  * `{:error, exception}` if the currency code is unknown or
-    the locale data cannot be loaded.
+  * `{:error, %Localize.UnknownCurrencyError{}}` if the currency
+    code is not a known ISO 4217 or registered custom currency.
+
+  * `{:error, %Localize.CurrencyNotLocalizedError{}}` if the
+    currency code is valid but has no entry in the requested
+    locale (and, when `:fallback` is `true`, no entry in any
+    fallback locale either).
+
+  * `{:error, exception}` if the locale data cannot be loaded.
 
   """
   @spec currency_for_code(atom() | String.t(), Keyword.t()) ::
           {:ok, t()} | {:error, Exception.t()}
   def currency_for_code(currency_code, options \\ []) do
     locale = Keyword.get(options, :locale, Localize.get_locale())
+    fallback? = Keyword.get(options, :fallback, false)
 
-    with {:ok, code} <- validate_currency(currency_code),
-         {:ok, currencies} <- currencies_for_locale(locale) do
+    with {:ok, code} <- validate_currency(currency_code) do
+      resolve_currency_for_code(code, locale, fallback?)
+    end
+  end
+
+  defp resolve_currency_for_code(code, locale, fallback?) do
+    with {:ok, currencies} <- currencies_for_locale(locale) do
       case Map.get(currencies, code) do
-        nil -> {:error, Localize.UnknownCurrencyError.exception(currency: currency_code)}
+        nil when fallback? -> fallback_currency_for_code(code, locale)
+        nil -> {:error, currency_not_localized_error(code, locale)}
         currency -> {:ok, currency}
       end
     end
+  end
+
+  defp fallback_currency_for_code(code, locale) do
+    chain = parent_chain(locale) ++ [Localize.default_locale()]
+
+    # Walk the chain looking for the currency. We only treat
+    # "currency absent in this locale's map" as continuable — real
+    # provider/load errors from `currencies_for_locale/1` are
+    # propagated rather than masked as `CurrencyNotLocalizedError`.
+    Enum.reduce_while(chain, :error, fn fallback_locale, _acc ->
+      case currencies_for_locale(fallback_locale) do
+        {:ok, currencies} ->
+          case Map.get(currencies, code) do
+            nil -> {:cont, :error}
+            currency -> {:halt, {:ok, currency}}
+          end
+
+        {:error, _} = error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, _currency} = ok -> ok
+      {:error, _exception} = error -> error
+      :error -> {:error, currency_not_localized_error(code, locale)}
+    end
+  end
+
+  defp parent_chain(locale) do
+    locale
+    |> Localize.Locale.to_locale_id()
+    |> walk_parents([])
+  end
+
+  defp walk_parents(locale_id, acc) do
+    case Localize.Locale.parent(to_string(locale_id)) do
+      {:ok, parent_tag} ->
+        parent_id = Localize.Locale.to_locale_id(parent_tag)
+
+        if parent_id in acc do
+          Enum.reverse(acc)
+        else
+          walk_parents(parent_id, [parent_id | acc])
+        end
+
+      {:error, _} ->
+        Enum.reverse(acc)
+    end
+  end
+
+  defp currency_not_localized_error(code, locale) do
+    Localize.CurrencyNotLocalizedError.exception(
+      currency: code,
+      locale: Localize.Locale.to_locale_id(locale)
+    )
   end
 
   @doc """

--- a/lib/localize/exception/currency_not_localized_error.ex
+++ b/lib/localize/exception/currency_not_localized_error.ex
@@ -1,0 +1,35 @@
+defmodule Localize.CurrencyNotLocalizedError do
+  @moduledoc """
+  Exception raised when a known currency code has no localized
+  data in the requested locale.
+
+  Distinct from `Localize.UnknownCurrencyError`, which signals
+  that the currency code itself is not a recognised ISO 4217 or
+  registered custom currency. This error means the code is valid
+  but the locale's CLDR currency map has no entry for it.
+
+  Pass `fallback: true` to `Localize.Currency.currency_for_code/2`
+  to walk the CLDR locale fallback chain (and the application
+  default locale) before failing with this error.
+
+  """
+
+  defexception [:currency, :locale]
+
+  @impl true
+  def exception(bindings) when is_list(bindings) do
+    struct!(__MODULE__, bindings)
+  end
+
+  @impl true
+  def message(%__MODULE__{currency: currency, locale: locale}) do
+    Gettext.dpgettext(
+      Localize.Gettext,
+      "localize",
+      "currency",
+      "The currency {$currency} has no localized data in locale {$locale}.",
+      currency: inspect(currency),
+      locale: inspect(locale)
+    )
+  end
+end

--- a/lib/localize/gettext/messages.ex
+++ b/lib/localize/gettext/messages.ex
@@ -27,6 +27,12 @@ defmodule Localize.Gettext.Messages do
         Localize.Gettext,
         "localize",
         "currency",
+        "The currency {$currency} has no localized data in locale {$locale}."
+      ),
+      Gettext.Macros.dpgettext_noop_with_backend(
+        Localize.Gettext,
+        "localize",
+        "currency",
         "The currency {$currency} is not known."
       ),
 

--- a/priv/gettext/localize.pot
+++ b/priv/gettext/localize.pot
@@ -17,338 +17,368 @@ msgctxt "currency"
 msgid "The currency {$currency} has no display name in locale {$locale}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:21
+#: lib/localize/gettext/messages.ex:32
 #, elixir-autogen, icu-format
 msgctxt "currency"
 msgid "The currency {$currency} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:24
+#: lib/localize/gettext/messages.ex:40
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "Could not tokenize the format {$format}: {$detail}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:25
+#: lib/localize/gettext/messages.ex:46
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "Date must have at least one of :year, :month, or :day keys."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:26
+#: lib/localize/gettext/messages.ex:52
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "Datetime must have date and/or time keys."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:27
+#: lib/localize/gettext/messages.ex:58
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "Invalid interval format {$detail}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:28
+#: lib/localize/gettext/messages.ex:64
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "No available format resolved for {$format} in locale {$locale}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:29
+#: lib/localize/gettext/messages.ex:70
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "No interval format found for {$format_key}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:30
+#: lib/localize/gettext/messages.ex:76
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "No interval pattern for difference {$detail} in format {$format_key}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:31
+#: lib/localize/gettext/messages.ex:82
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "The format {$format} is invalid."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:32
+#: lib/localize/gettext/messages.ex:88
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "The format {$format} is invalid: {$reason}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:33
+#: lib/localize/gettext/messages.ex:94
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "Time must have at least one of :hour, :minute, or :second keys."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:34
+#: lib/localize/gettext/messages.ex:100
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "Unknown interval style {$style} or format {$format}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:35
+#: lib/localize/gettext/messages.ex:106
 #, elixir-autogen, icu-format
 msgctxt "datetime"
 msgid "Unterminated quote in interval format."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:38
+#: lib/localize/gettext/messages.ex:120
 #, elixir-autogen, icu-format
 msgctxt "language_tag"
 msgid "Could not parse {$input}: {$reason}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:39
+#: lib/localize/gettext/messages.ex:134
 #, elixir-autogen, icu-format
 msgctxt "language_tag"
 msgid "No likely subtags data found for {$locale}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:40
+#: lib/localize/gettext/messages.ex:140
 #, elixir-autogen, icu-format
 msgctxt "language_tag"
 msgid "No matching locale found for {$desired} within distance {$threshold}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:41
+#: lib/localize/gettext/messages.ex:146
 #, elixir-autogen, icu-format
 msgctxt "language_tag"
 msgid "No unicode script {$value} found."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:42
+#: lib/localize/gettext/messages.ex:152
 #, elixir-autogen, icu-format
 msgctxt "language_tag"
 msgid "The date {$value} must be the last value in subtag {$key}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:43
+#: lib/localize/gettext/messages.ex:158
 #, elixir-autogen, icu-format
 msgctxt "language_tag"
 msgid "The key {$key} is not valid for the -u- subtag."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:44
+#: lib/localize/gettext/messages.ex:164
 #, elixir-autogen, icu-format
 msgctxt "language_tag"
 msgid "The value {$value} is not valid for the key {$key}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:47
+#: lib/localize/gettext/messages.ex:172
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "No locale display data for {$locale}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:48
+#: lib/localize/gettext/messages.ex:178
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "No parent territory found for {$territory}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:49
+#: lib/localize/gettext/messages.ex:184
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The cached locale {$locale_id} has version {$cached_version} but the current version is {$current_version}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:50
+#: lib/localize/gettext/messages.ex:190
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The calendar {$calendar} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:51
+#: lib/localize/gettext/messages.ex:196
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The key path {$keys} was not found in locale {$locale}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:52
+#: lib/localize/gettext/messages.ex:202
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The language {$language} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:53
+#: lib/localize/gettext/messages.ex:208
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The locale {$locale_id} could not be downloaded from {$url}: {$reason}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:54
+#: lib/localize/gettext/messages.ex:214
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The locale {$locale_id} could not be written to the cache at {$path}: {$reason}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:55
+#: lib/localize/gettext/messages.ex:220
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The locale {$locale_id} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:56
+#: lib/localize/gettext/messages.ex:226
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The locale {$locale_id} is not valid."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:57
+#: lib/localize/gettext/messages.ex:232
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The locale {$locale_id} was not found in the cache at {$path}. Run `mix localize.download_locales {$locale_id_bare}` to download it, or set `config :localize, :allow_runtime_locale_download, true` to enable on-demand downloading."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:58
+#: lib/localize/gettext/messages.ex:238
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The locale {$locale} has no parent locale"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:59
+#: lib/localize/gettext/messages.ex:244
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The script {$script} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:60
+#: lib/localize/gettext/messages.ex:250
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The subdivision {$subdivision} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:61
+#: lib/localize/gettext/messages.ex:256
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "The territory {$territory} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:62
+#: lib/localize/gettext/messages.ex:262
 #, elixir-autogen, icu-format
 msgctxt "locale"
 msgid "Unknown timezone: {$timezone}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:65
+#: lib/localize/gettext/messages.ex:270
 #, elixir-autogen, icu-format
 msgctxt "message"
 msgid "Cannot format {$value} with function {$function}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:66
+#: lib/localize/gettext/messages.ex:276
 #, elixir-autogen, icu-format
 msgctxt "message"
 msgid "Cannot format {$value} with function {$function}: {$reason}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:67
+#: lib/localize/gettext/messages.ex:282
 #, elixir-autogen, icu-format
 msgctxt "message"
 msgid "No binding was found for {$unbound}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:71
+#: lib/localize/gettext/messages.ex:302
 #, elixir-autogen, icu-format
 msgctxt "number"
 msgid "The measurement system {$measurement_system} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:70
+#: lib/localize/gettext/messages.ex:290
 #, elixir-autogen, icu-format
 msgctxt "number"
 msgid "The number system {$number_system} is not known."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:74
+#: lib/localize/gettext/messages.ex:316
 #, elixir-autogen, icu-format
 msgctxt "plural_rules"
 msgid "No{$type} plural rules available for the locale {$locale_id}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:77
+#: lib/localize/gettext/messages.ex:324
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Cannot apply {$operation} to a unit without a value."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:78
+#: lib/localize/gettext/messages.ex:330
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Cannot compute conversion factor for mixed units."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:79
+#: lib/localize/gettext/messages.ex:336
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Cannot convert from {$from} to {$to}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:80
+#: lib/localize/gettext/messages.ex:342
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Expected {$expected} for {$context}, got: {$value}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:81
+#: lib/localize/gettext/messages.ex:348
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Expected {$expected}, got: {$value}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:82
+#: lib/localize/gettext/messages.ex:354
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "No quantity found for base unit {$unit}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:83
+#: lib/localize/gettext/messages.ex:360
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "No unit preference for region {$region} in category {$category}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:84
+#: lib/localize/gettext/messages.ex:366
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "No unit preferences for category {$category} and usage {$usage}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:85
+#: lib/localize/gettext/messages.ex:372
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "No unit preferences found for quantity {$quantity}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:86
+#: lib/localize/gettext/messages.ex:378
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Special conversion is not supported for {$from}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:87
+#: lib/localize/gettext/messages.ex:384
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Units {$from} and {$to} are not convertible."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:88
+#: lib/localize/gettext/messages.ex:390
 #, elixir-autogen, icu-format
 msgctxt "unit"
 msgid "Unknown unit: {$unit}"
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:92
+#: lib/localize/gettext/messages.ex:404
 #, elixir-autogen, icu-format
 msgctxt "unknown style error"
 msgid "The style {$style} is unknown for territory {$territory}."
 msgstr ""
 
-#: lib/localize/gettext/messages.ex:91
+#: lib/localize/gettext/messages.ex:398
 #, elixir-autogen, icu-format
 msgctxt "unknown style error"
 msgid "The style {$style} is unknown."
+msgstr ""
+
+#: lib/localize/gettext/messages.ex:26
+#, elixir-autogen, icu-format
+msgctxt "currency"
+msgid "The currency {$currency} has no localized data in locale {$locale}."
+msgstr ""
+
+#: lib/localize/gettext/messages.ex:112
+#, elixir-autogen, icu-format
+msgctxt "datetime"
+msgid "No interval format fallback pattern available in the locale data."
+msgstr ""
+
+#: lib/localize/gettext/messages.ex:128
+#, elixir-autogen, icu-format
+msgctxt "message"
+msgid "Could not parse {$input} at line {$line} column {$column}: {$reason}"
+msgstr ""
+
+#: lib/localize/gettext/messages.ex:308
+#, elixir-autogen, icu-format
+msgctxt "number"
+msgid "The RBNF rule {$rule_name} is not known for locale {$locale}."
+msgstr ""
+
+#: lib/localize/gettext/messages.ex:296
+#, elixir-autogen, icu-format
+msgctxt "number"
+msgid "The number system {$number_system} is not valid for locale {$locale}."
 msgstr ""

--- a/test/localize/currency_test.exs
+++ b/test/localize/currency_test.exs
@@ -204,6 +204,41 @@ defmodule Localize.CurrencyTest do
                Currency.currency_for_code(:ZZZ)
     end
 
+    test "currency_for_code returns CurrencyNotLocalizedError for valid currency missing in locale" do
+      # VED (Bolívar Soberano) and UYW (Uruguayan Nominal Wage Index Unit) are
+      # tender currencies whose CLDR display names exist in :en but not in many
+      # other locales. Without :fallback, the request must fail explicitly
+      # rather than returning {:ok, nil} or masking as UnknownCurrencyError.
+      assert {:error, %Localize.CurrencyNotLocalizedError{currency: :VED, locale: :es}} =
+               Currency.currency_for_code(:VED, locale: :es)
+
+      assert {:error, %Localize.CurrencyNotLocalizedError{currency: :UYW, locale: :de}} =
+               Currency.currency_for_code(:UYW, locale: :de)
+    end
+
+    test "currency_for_code with fallback: true walks the locale chain" do
+      assert {:ok, currency} = Currency.currency_for_code(:VED, locale: :es, fallback: true)
+      assert currency.code == :VED
+      assert is_binary(currency.name)
+
+      assert {:ok, currency} = Currency.currency_for_code(:UYW, locale: :de, fallback: true)
+      assert currency.code == :UYW
+      assert is_binary(currency.name)
+    end
+
+    test "currency_for_code with fallback: true still errors for unknown codes" do
+      assert {:error, %Localize.UnknownCurrencyError{}} =
+               Currency.currency_for_code(:ZZZ, locale: :es, fallback: true)
+    end
+
+    test "currency_for_code with fallback: true uses requested locale when data exists" do
+      # When the requested locale already has the currency, fallback must not
+      # change the answer.
+      assert {:ok, currency} = Currency.currency_for_code(:USD, locale: :fr, fallback: true)
+      assert currency.code == :USD
+      assert currency.name == "dollar des États-Unis"
+    end
+
     test "currencies_for_locale returns all currencies for a locale" do
       assert {:ok, currencies} = Currency.currencies_for_locale(:en)
       assert is_map(currencies)


### PR DESCRIPTION
## Summary

Mirrors the fix you shipped in `ex_cldr_currencies` v2.17.2 (elixir-cldr/cldr_currencies#19) for the equivalent issue in Localize. On `main`, `Localize.Currency.currency_for_code(:VED, locale: :es)` returns `{:error, %Localize.UnknownCurrencyError{}}` — the same error you get for `:ZZZ` — even though VED is a known tender currency that simply lacks Spanish-locale display data in CLDR.

## Changes

- New `Localize.CurrencyNotLocalizedError` distinguishes "valid currency, no data in this locale" from "unknown currency code".
- `currency_for_code/2` accepts `fallback: true` (default `false`). When set, walks `Localize.Locale.parent/1` and then `Localize.default_locale/0` looking for the currency before failing.
- Real provider/load errors from `currencies_for_locale/1` propagate through the fallback chain rather than being masked as `CurrencyNotLocalizedError`.
- Tests for the new error type, fallback happy path, and that unknown codes still error under `fallback: true`.

## Behaviour change

Callers that pattern-matched `{:error, %Localize.UnknownCurrencyError{}}` to detect the "missing in locale" case will now see `%Localize.CurrencyNotLocalizedError{}` instead. The original `UnknownCurrencyError` is unchanged for genuinely unknown currency codes.

## Notes

- `mix gettext.extract` picked up 4 unrelated pre-existing messages that are declared in `Localize.Gettext.Messages` but were never extracted to `priv/gettext/localize.pot` (interval-format-fallback, MF2 parse with line/column, RBNF rule, number-system-not-valid). Those are in the .pot diff but aren't from this PR.
- I left CHANGELOG and version bump alone — happy to add an entry in whatever section/format you prefer if you'd like me to.

Tested locally with `mix test` (23758 tests, 0 failures).