### PR TITLE
Do not load runtime config in "mix localize.download_locales"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [0.31.0] — May 13th, 2026
 
+### Bug Fixes
+
+* `mix localize.download_locales` no longer evaluates `config/runtime.exs` of the consumer application. Previously the task ran `Mix.Task.run("app.config")`, which transitively evaluated `runtime.exs`, which was not necessary. The task now loads only compile-time config (`config/config.exs` and any imported env-specific file), matching the build-time contract its docstring already advertised.
+
 ### Behaviour Changes
 
 * `Localize.InvalidValueError` gained an `:allowed_values` field and a new `Localize.NoCertificateStoreError` carries the searched paths; previously prose-stuffed `:expected`/`:currency` fields and bare-string `:reason` codes are now structural.

--- a/lib/mix/tasks/localize.download_locales.ex
+++ b/lib/mix/tasks/localize.download_locales.ex
@@ -43,6 +43,15 @@ defmodule Mix.Tasks.Localize.DownloadLocales do
 
       config :localize, locale_cache_dir: "/path/to/cache"
 
+  ## Compile-time configuration
+
+  The task only loads compile-time configuration (`config/config.exs` and any
+  imported env-specific files) and never evaluates `config/runtime.exs`. This
+  makes it safe to run inside "build-only" environments (such as Docker images)
+  where production-only environment variables are deliberately not available.
+
+  The task itself reads only `:localize`'s own compile-time config.
+
   ## Examples
 
   Pre-populate the cache for a Docker build:
@@ -65,13 +74,18 @@ defmodule Mix.Tasks.Localize.DownloadLocales do
   alias Localize.Locale.Provider
   alias Localize.Locale.Provider.Cache
 
+  # Compile the consumer's code so `:localize` and its deps are
+  # available, and load compile-time config so `:supported_locales`
+  # and `:locale_cache_dir` are populated. We deliberately do NOT
+  # run `app.config`: that evaluates `config/runtime.exs`, which in
+  # build environments (Docker images, CI) typically requires
+  # production env vars that aren't available.
+  # `loadconfig` reads `config/config.exs` (and any imported
+  # env-specific file) but stops short of `runtime.exs`.
+  @requirements ["compile", "loadconfig"]
+
   @impl Mix.Task
   def run(args) do
-    # Compile and load runtime config without starting the consumer's
-    # own application — the consumer may not be startable in a build
-    # environment (no DB, no network endpoint, etc.). We only need
-    # `:localize` itself running for the download.
-    Mix.Task.run("app.config")
     {:ok, _started} = Application.ensure_all_started(:localize)
 
     {opts, locale_args} =


### PR DESCRIPTION
Hey @kipcole9, fantastic work on this library! This patch would make it usable for us, given we build an image in Docker and we don't have any of the `runtime.exs` env variables available at that stage.

Thoughts? 🙃 

I messed with the changelog but let me know if you'd rather do that instead, I can revert those changes.