### PR TITLE
Resolve number_systems ETF path at runtime, not compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [0.34.0] — Unreleased
 
+### Bug Fixes
+
+* `Localize.Number.System` no longer bakes the build host's absolute ETF path into its compiled BEAM. `@number_systems_path` was assigned `Application.app_dir/2` at compile time, which meant a Mix release built on one host and run on another (e.g. a CI runner producing a release that ships to a production VM) crashed on `Application.start/2` when the 0.33.0 eager-intern hook called `load_number_systems/0` against the frozen build-host path with `File.Error` / `:enoent`. The lookup now happens at runtime via `Application.app_dir/2` from a function body.
+
 ### Enhancements
 
 

--- a/lib/localize/number/system.ex
+++ b/lib/localize/number/system.ex
@@ -35,11 +35,6 @@ defmodule Localize.Number.System do
 
   @known_number_system_types [:default, :native, :traditional, :finance]
 
-  @number_systems_path Application.app_dir(
-                         :localize,
-                         "priv/localize/supplemental_data/number_systems.etf"
-                       )
-
   # Lazy-load number systems from ETF at runtime and cache in persistent_term.
   @persistent_term_key {:localize, :number_systems}
   @numeric_systems_key {:localize, :numeric_systems}
@@ -660,9 +655,17 @@ defmodule Localize.Number.System do
 
   # ── Private helpers ──────────────────────────────────────────
 
+  # Resolve the ETF path at runtime. Storing `Application.app_dir/2` in a
+  # module attribute bakes the build host's absolute path into the BEAM,
+  # which then fails to read on the target host of a Mix release built on
+  # a different machine (e.g. CI runner -> production VM).
+  defp number_systems_path do
+    Application.app_dir(:localize, "priv/localize/supplemental_data/number_systems.etf")
+  end
+
   defp load_number_systems do
     Localize.DataLoader.load(@persistent_term_key, fn ->
-      systems = @number_systems_path |> File.read!() |> :erlang.binary_to_term()
+      systems = number_systems_path() |> File.read!() |> :erlang.binary_to_term()
 
       numeric =
         systems

--- a/test/localize/release_path_resilience_test.exs
+++ b/test/localize/release_path_resilience_test.exs
@@ -1,0 +1,42 @@
+defmodule Localize.ReleasePathResilienceTest do
+  use ExUnit.Case, async: true
+
+  # Regression: `Application.app_dir/2` evaluated inside a module attribute
+  # bakes the build host's absolute path into the compiled BEAM. A Mix release
+  # built on one host and run on another (e.g. CI runner -> Fly machine) then
+  # crashes at boot when the runtime tries to read that frozen path:
+  #
+  #     ** (File.Error) could not read file
+  #        "/home/runner/work/.../_build/dev/lib/localize/priv/localize/
+  #         supplemental_data/number_systems.etf": no such file or directory
+  #
+  # Module attributes that need the path at *runtime* must call
+  # `Application.app_dir/2` from inside a function body so the lookup happens
+  # against the runtime application controller, not the compile-time one.
+  describe "ETF data paths used at runtime" do
+    test "Localize.Number.System does not bake an absolute priv path into the BEAM" do
+      absolute =
+        Application.app_dir(
+          :localize,
+          "priv/localize/supplemental_data/number_systems.etf"
+        )
+
+      beam_bytes =
+        Localize.Number.System
+        |> :code.which()
+        |> File.read!()
+
+      refute String.contains?(beam_bytes, absolute),
+             """
+             Localize.Number.System has the absolute path
+
+                 #{absolute}
+
+             baked into its compiled BEAM. This means a release built on this
+             host will crash at boot on any other host. The path must be
+             resolved at runtime via `Application.app_dir/2` called from a
+             function body, not from a module attribute.
+             """
+    end
+  end
+end


### PR DESCRIPTION
Fixes #28.

## Summary

`Localize.Number.System` stored `Application.app_dir/2` in `@number_systems_path` at compile time, baking the build host's absolute path into the compiled BEAM. The 0.33.0 eager-intern hook in `Localize.Application.start/2` then called `load_number_systems/0` against that frozen path, so any Mix release built on one host and run on another (CI runner → production VM, Docker multi-stage, etc.) crashed on boot with `File.Error` / `:enoent`.

## Change

Move the lookup into a private function so `Application.app_dir/2` runs against the runtime application controller instead of the compile-time one. No behaviour change beyond the path resolution timing.

## Regression test

Adds `test/localize/release_path_resilience_test.exs`, which reads `Localize.Number.System`'s compiled BEAM and asserts the absolute resolved priv path is not present anywhere in it. Verified the test fails on `main` (catches the bug) and passes on this branch (proves the fix).

Full suite: 633 doctests, 17 properties, 23,845 tests, 0 failures.

## Scope

The same anti-pattern (compile-time `Application.app_dir/2` in a module attribute) exists in `lib/localize/unit/data.ex`, `lib/localize/datetime/format/match.ex`, and `lib/localize/collation/tailoring.ex`, but in those three the data is fully consumed at compile time (folded into `@data` / `@time_preferences` / `@tailorings`) so the path is never re-read on the runtime host today. They are a latent footgun (`@external_resource` ends up pointing at a build-host absolute path, and any future runtime read of `@*_path` would crash the same way) but they don't crash today, so I left them out of this PR — happy to follow up if you want them converted too.