### PR TITLE
Run app.config for localize.download_locales

### DIFF
--- a/lib/mix/tasks/localize.download_locales.ex
+++ b/lib/mix/tasks/localize.download_locales.ex
@@ -86,6 +86,7 @@ defmodule Mix.Tasks.Localize.DownloadLocales do
 
   @impl Mix.Task
   def run(args) do
+    Mix.Task.run("app.config")
     {:ok, _started} = Application.ensure_all_started(:localize)
 
     {opts, locale_args} =


### PR DESCRIPTION
This is necessary so runtime.exs gets evaluated, which is the only place `Gettext.known_locales(Backend)` can be called.