### PR TITLE
Consult zone-level timezone names; apply locale default numbering systems

### DIFF
--- a/lib/localize/datetime/formatter.ex
+++ b/lib/localize/datetime/formatter.ex
@@ -66,6 +66,8 @@ defmodule Localize.DateTime.Formatter do
   @spec format(map(), String.t(), atom(), map()) ::
           {:ok, String.t()} | {:error, Exception.t()}
   def format(datetime, format_string, locale_id, options \\ %{}) do
+    options = with_default_number_system(options, locale_id)
+
     with {:ok, tokens, _} <- tokenize_cached(format_string) do
       results =
         Enum.map(tokens, fn
@@ -135,6 +137,21 @@ defmodule Localize.DateTime.Formatter do
   end
 
   defp trim_leading_whitespace_in_next(rest_t, rest_r), do: {rest_t, rest_r}
+
+  defp with_default_number_system(options, locale_id) when is_map(options) do
+    overrides = options[:number_system_overrides] || options["number_system_overrides"] || %{}
+
+    with %{} <- overrides,
+         false <- Map.has_key?(overrides, "all"),
+         {:ok, system} when system != :latn <-
+           Localize.Number.System.system_name_from(:default, locale_id) do
+      Map.put(options, :number_system_overrides, Map.put(overrides, "all", system))
+    else
+      _ -> options
+    end
+  end
+
+  defp with_default_number_system(options, _locale_id), do: options
 
   defp tokenize_cached(format_string) do
     key = {:localize, :datetime_format_tokens, format_string}
@@ -328,19 +345,19 @@ defmodule Localize.DateTime.Formatter do
   # ── Week-aligned year (Y) ──────────────────────────────────
 
   @doc false
-  def week_aligned_year(date, 1, locale_id, _options) when is_date(date) do
+  def week_aligned_year(date, 1, locale_id, options) when is_date(date) do
     {year, _week} = locale_week_of_year(date, locale_id)
-    Kernel.to_string(year)
+    year |> Kernel.to_string() |> apply_ns(locale_id, options, "Y")
   end
 
-  def week_aligned_year(date, 2, locale_id, _options) when is_date(date) do
+  def week_aligned_year(date, 2, locale_id, options) when is_date(date) do
     {year, _week} = locale_week_of_year(date, locale_id)
-    year |> rem(100) |> pad(2)
+    year |> rem(100) |> pad(2) |> apply_ns(locale_id, options, "Y")
   end
 
-  def week_aligned_year(date, count, locale_id, _options) when is_date(date) and count in 3..5 do
+  def week_aligned_year(date, count, locale_id, options) when is_date(date) and count in 3..5 do
     {year, _week} = locale_week_of_year(date, locale_id)
-    pad(year, count)
+    year |> pad(count) |> apply_ns(locale_id, options, "Y")
   end
 
   def week_aligned_year(_date, _count, _locale_id, _options), do: ""
@@ -348,8 +365,8 @@ defmodule Localize.DateTime.Formatter do
   # ── Extended year (u) ──────────────────────────────────────
 
   @doc false
-  def extended_year(%{year: year}, count, _locale_id, _options) do
-    pad(year, count)
+  def extended_year(%{year: year}, count, locale_id, options) do
+    year |> pad(count) |> apply_ns(locale_id, options, "u")
   end
 
   def extended_year(_date, _count, _locale_id, _options), do: ""
@@ -431,12 +448,12 @@ defmodule Localize.DateTime.Formatter do
   # ── Quarter (Q) ────────────────────────────────────────────
 
   @doc false
-  def quarter(date, 1, _locale_id, _options) when has_month(date) do
-    quarter_of_year(date)
+  def quarter(date, 1, locale_id, options) when has_month(date) do
+    quarter_of_year(date) |> apply_ns(locale_id, options, "Q")
   end
 
-  def quarter(date, 2, _locale_id, _options) when has_month(date) do
-    quarter_of_year(date) |> pad(2)
+  def quarter(date, 2, locale_id, options) when has_month(date) do
+    quarter_of_year(date) |> pad(2) |> apply_ns(locale_id, options, "Q")
   end
 
   def quarter(date, 3, locale_id, _options) when has_month(date) do
@@ -456,12 +473,12 @@ defmodule Localize.DateTime.Formatter do
   # ── Standalone Quarter (q) ─────────────────────────────────
 
   @doc false
-  def standalone_quarter(date, 1, _locale_id, _options) when has_month(date) do
-    quarter_of_year(date)
+  def standalone_quarter(date, 1, locale_id, options) when has_month(date) do
+    quarter_of_year(date) |> apply_ns(locale_id, options, "q")
   end
 
-  def standalone_quarter(date, 2, _locale_id, _options) when has_month(date) do
-    quarter_of_year(date) |> pad(2)
+  def standalone_quarter(date, 2, locale_id, options) when has_month(date) do
+    quarter_of_year(date) |> pad(2) |> apply_ns(locale_id, options, "q")
   end
 
   def standalone_quarter(date, count, locale_id, _options)
@@ -496,9 +513,11 @@ defmodule Localize.DateTime.Formatter do
   # ── Standalone Month (L) ───────────────────────────────────
 
   @doc false
-  def standalone_month(%{month: month}, 1, _locale_id, _options), do: month
+  def standalone_month(%{month: month}, 1, locale_id, options),
+    do: month |> apply_ns(locale_id, options, "L")
 
-  def standalone_month(%{month: month}, 2, _locale_id, _options), do: pad(month, 2)
+  def standalone_month(%{month: month}, 2, locale_id, options),
+    do: pad(month, 2) |> apply_ns(locale_id, options, "L")
 
   def standalone_month(date, count, locale_id, _options) when has_month(date) and count in 3..5 do
     format = format_for_count(count)
@@ -515,14 +534,14 @@ defmodule Localize.DateTime.Formatter do
   # ── Week of Year (w) ───────────────────────────────────────
 
   @doc false
-  def week_of_year(date, 1, locale_id, _options) when is_date(date) do
+  def week_of_year(date, 1, locale_id, options) when is_date(date) do
     {_year, week} = locale_week_of_year(date, locale_id)
-    week
+    apply_ns(week, locale_id, options, "w")
   end
 
-  def week_of_year(date, 2, locale_id, _options) when is_date(date) do
+  def week_of_year(date, 2, locale_id, options) when is_date(date) do
     {_year, week} = locale_week_of_year(date, locale_id)
-    pad(week, 2)
+    week |> pad(2) |> apply_ns(locale_id, options, "w")
   end
 
   def week_of_year(_date, _count, _locale_id, _options), do: ""
@@ -534,7 +553,7 @@ defmodule Localize.DateTime.Formatter do
         %{year: year, month: month, day: day, calendar: Calendar.ISO},
         _count,
         locale_id,
-        _options
+        options
       ) do
     {first_day, min_days} = week_config(locale_id)
     first_of_month_dow = :calendar.day_of_the_week({year, month, 1})
@@ -544,11 +563,12 @@ defmodule Localize.DateTime.Formatter do
     # Week 1 exists only when the first (possibly partial) week of the
     # month holds at least min_days days; otherwise that partial week
     # counts as week 0 per ICU.
-    if 7 - offset >= min_days, do: raw_week, else: raw_week - 1
+    week = if 7 - offset >= min_days, do: raw_week, else: raw_week - 1
+    apply_ns(week, locale_id, options, "W")
   end
 
-  def week_of_month(%{day: day}, _count, _locale_id, _options) when is_integer(day) do
-    div(day - 1, 7) + 1
+  def week_of_month(%{day: day}, _count, locale_id, options) when is_integer(day) do
+    (div(day - 1, 7) + 1) |> apply_ns(locale_id, options, "W")
   end
 
   def week_of_month(_date, _count, _locale_id, _options), do: ""
@@ -567,9 +587,10 @@ defmodule Localize.DateTime.Formatter do
   # ── Day of Year (D) ────────────────────────────────────────
 
   @doc false
-  def day_of_year(date, count, _locale_id, _options) when is_date(date) do
+  def day_of_year(date, count, locale_id, options) when is_date(date) do
     doy = compute_day_of_year(date)
-    if count == 1, do: doy, else: pad(doy, count)
+    doy = if count == 1, do: doy, else: pad(doy, count)
+    apply_ns(doy, locale_id, options, "D")
   end
 
   def day_of_year(_date, _count, _locale_id, _options), do: ""
@@ -577,8 +598,8 @@ defmodule Localize.DateTime.Formatter do
   # ── Day of Week in Month (F) ───────────────────────────────
 
   @doc false
-  def day_of_week_in_month(%{day: day}, _count, _locale_id, _options) do
-    div(day - 1, 7) + 1
+  def day_of_week_in_month(%{day: day}, _count, locale_id, options) do
+    (div(day - 1, 7) + 1) |> apply_ns(locale_id, options, "F")
   end
 
   def day_of_week_in_month(_date, _count, _locale_id, _options), do: ""
@@ -604,12 +625,12 @@ defmodule Localize.DateTime.Formatter do
   # ── Day of Week number (e) ─────────────────────────────────
 
   @doc false
-  def day_of_week(date, 1, _locale_id, _options) when is_date(date) do
-    iso_day(date)
+  def day_of_week(date, 1, locale_id, options) when is_date(date) do
+    iso_day(date) |> apply_ns(locale_id, options, "e")
   end
 
-  def day_of_week(date, 2, _locale_id, _options) when is_date(date) do
-    pad(iso_day(date), 2)
+  def day_of_week(date, 2, locale_id, options) when is_date(date) do
+    iso_day(date) |> pad(2) |> apply_ns(locale_id, options, "e")
   end
 
   def day_of_week(date, count, locale_id, options) when is_date(date) and count >= 3 do
@@ -621,12 +642,12 @@ defmodule Localize.DateTime.Formatter do
   # ── Standalone Day of Week (c) ─────────────────────────────
 
   @doc false
-  def standalone_day_of_week(date, 1, _locale_id, _options) when is_date(date) do
-    iso_day(date)
+  def standalone_day_of_week(date, 1, locale_id, options) when is_date(date) do
+    iso_day(date) |> apply_ns(locale_id, options, "c")
   end
 
-  def standalone_day_of_week(date, 2, _locale_id, _options) when is_date(date) do
-    pad(iso_day(date), 2)
+  def standalone_day_of_week(date, 2, locale_id, options) when is_date(date) do
+    iso_day(date) |> pad(2) |> apply_ns(locale_id, options, "c")
   end
 
   def standalone_day_of_week(date, count, locale_id, _options)
@@ -758,15 +779,16 @@ defmodule Localize.DateTime.Formatter do
   # ── Hour 1-12 (h) ─────────────────────────────────────────
 
   @doc false
-  def h12(%{hour: hour}, 1, _locale_id, _options) do
-    h = rem(hour, 12)
-    if h == 0, do: 12, else: h
-  end
-
-  def h12(%{hour: hour}, count, _locale_id, _options) do
+  def h12(%{hour: hour}, 1, locale_id, options) do
     h = rem(hour, 12)
     h = if h == 0, do: 12, else: h
-    pad(h, count)
+    apply_ns(h, locale_id, options, "h")
+  end
+
+  def h12(%{hour: hour}, count, locale_id, options) do
+    h = rem(hour, 12)
+    h = if h == 0, do: 12, else: h
+    h |> pad(count) |> apply_ns(locale_id, options, "h")
   end
 
   def h12(_time, _count, _locale_id, _options), do: ""
@@ -774,10 +796,11 @@ defmodule Localize.DateTime.Formatter do
   # ── Hour 0-11 (K) ─────────────────────────────────────────
 
   @doc false
-  def h11(%{hour: hour}, 1, _locale_id, _options), do: rem(hour, 12)
+  def h11(%{hour: hour}, 1, locale_id, options),
+    do: rem(hour, 12) |> apply_ns(locale_id, options, "K")
 
-  def h11(%{hour: hour}, count, _locale_id, _options) do
-    rem(hour, 12) |> pad(count)
+  def h11(%{hour: hour}, count, locale_id, options) do
+    rem(hour, 12) |> pad(count) |> apply_ns(locale_id, options, "K")
   end
 
   def h11(_time, _count, _locale_id, _options), do: ""
@@ -785,22 +808,24 @@ defmodule Localize.DateTime.Formatter do
   # ── Hour 0-23 (H) ─────────────────────────────────────────
 
   @doc false
-  def h23(%{hour: hour}, 1, _locale_id, _options), do: hour
+  def h23(%{hour: hour}, 1, locale_id, options), do: apply_ns(hour, locale_id, options, "H")
 
-  def h23(%{hour: hour}, count, _locale_id, _options), do: pad(hour, count)
+  def h23(%{hour: hour}, count, locale_id, options),
+    do: hour |> pad(count) |> apply_ns(locale_id, options, "H")
 
   def h23(_time, _count, _locale_id, _options), do: ""
 
   # ── Hour 1-24 (k) ─────────────────────────────────────────
 
   @doc false
-  def h24(%{hour: hour}, 1, _locale_id, _options) do
-    if hour == 0, do: 24, else: hour
+  def h24(%{hour: hour}, 1, locale_id, options) do
+    h = if hour == 0, do: 24, else: hour
+    apply_ns(h, locale_id, options, "k")
   end
 
-  def h24(%{hour: hour}, count, _locale_id, _options) do
+  def h24(%{hour: hour}, count, locale_id, options) do
     h = if hour == 0, do: 24, else: hour
-    pad(h, count)
+    h |> pad(count) |> apply_ns(locale_id, options, "k")
   end
 
   def h24(_time, _count, _locale_id, _options), do: ""
@@ -808,29 +833,33 @@ defmodule Localize.DateTime.Formatter do
   # ── Minute (m) ─────────────────────────────────────────────
 
   @doc false
-  def minute(%{minute: minute}, 1, _locale_id, _options), do: minute
+  def minute(%{minute: minute}, 1, locale_id, options),
+    do: apply_ns(minute, locale_id, options, "m")
 
-  def minute(%{minute: minute}, count, _locale_id, _options), do: pad(minute, count)
+  def minute(%{minute: minute}, count, locale_id, options),
+    do: minute |> pad(count) |> apply_ns(locale_id, options, "m")
 
   def minute(_time, _count, _locale_id, _options), do: ""
 
   # ── Second (s) ─────────────────────────────────────────────
 
   @doc false
-  def second(%{second: second}, 1, _locale_id, _options), do: second
+  def second(%{second: second}, 1, locale_id, options),
+    do: apply_ns(second, locale_id, options, "s")
 
-  def second(%{second: second}, count, _locale_id, _options), do: pad(second, count)
+  def second(%{second: second}, count, locale_id, options),
+    do: second |> pad(count) |> apply_ns(locale_id, options, "s")
 
   def second(_time, _count, _locale_id, _options), do: ""
 
   # ── Fractional Second (S) ──────────────────────────────────
 
   @doc false
-  def fractional_second(%{microsecond: {microsecond, precision}}, count, _locale_id, _options) do
+  def fractional_second(%{microsecond: {microsecond, precision}}, count, locale_id, options) do
     # Display `count` digits of the fractional second
     digits = min(count, max(precision, 1))
     fraction = div(microsecond, trunc(:math.pow(10, 6 - digits)))
-    pad(fraction, digits)
+    fraction |> pad(digits) |> apply_ns(locale_id, options, "S")
   end
 
   def fractional_second(_time, _count, _locale_id, _options), do: ""
@@ -843,7 +872,7 @@ defmodule Localize.DateTime.Formatter do
   # ── Millisecond (A) ────────────────────────────────────────
 
   @doc false
-  def millisecond(%{hour: h, minute: m, second: s} = time, count, _locale_id, _options) do
+  def millisecond(%{hour: h, minute: m, second: s} = time, count, locale_id, options) do
     ms = (h * 3600 + m * 60 + s) * 1000
 
     ms =
@@ -852,7 +881,7 @@ defmodule Localize.DateTime.Formatter do
         _ -> ms
       end
 
-    pad(ms, count)
+    ms |> pad(count) |> apply_ns(locale_id, options, "A")
   end
 
   def millisecond(_time, _count, _locale_id, _options), do: ""

--- a/lib/localize/datetime/timezone.ex
+++ b/lib/localize/datetime/timezone.ex
@@ -419,10 +419,9 @@ defmodule Localize.DateTime.Timezone do
   @doc """
   Returns the specific or generic non-location timezone name.
 
-  Looks up the metazone name for the datetime's timezone in the
+  Looks up the zone's own name, then its metazone name, in the
   locale's timezone data (e.g., "Eastern Standard Time"). When the
-  timezone has no metazone mapping, or the locale carries no name
-  for it, falls back to `gmt_format/3`.
+  locale carries neither, falls back to `gmt_format/3`.
 
   ### Arguments
 
@@ -473,9 +472,9 @@ defmodule Localize.DateTime.Timezone do
     type = Keyword.get(options, :type, :specific)
 
     with {:ok, tz_data} <- Localize.Locale.get(locale_id, [:dates, :time_zone_names]) do
-      # Try metazone lookup first
-      metazone_key = metazone_for(time_zone, datetime)
-      result = metazone_name(metazone_key, tz_data, format, type, datetime)
+      result =
+        zone_name(time_zone, tz_data, format, type, datetime) ||
+          metazone_name(metazone_for(time_zone, datetime), tz_data, format, type, datetime)
 
       if result do
         {:ok, result}
@@ -485,6 +484,37 @@ defmodule Localize.DateTime.Timezone do
       end
     end
   end
+
+  defp zone_name(time_zone, tz_data, format, type, datetime) when is_binary(time_zone) do
+    keys =
+      @zone_canonical_names
+      |> Map.get(time_zone, time_zone)
+      |> String.downcase()
+      |> String.split("/")
+      |> Enum.map(&existing_atom/1)
+
+    zone_data = get_in(tz_data[:zone], keys)
+
+    metazone_data_name(zone_data, format, type, datetime) ||
+      zone_standard_for_generic(zone_data, format, type)
+  end
+
+  defp zone_name(_time_zone, _tz_data, _format, _type, _datetime), do: nil
+
+  defp existing_atom(string) do
+    String.to_existing_atom(string)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp zone_standard_for_generic(%{} = zone_data, format, :generic) do
+    unless get_in(zone_data, [:long, :daylight]) || get_in(zone_data, [:short, :daylight]) do
+      format_key = if format == :short, do: :short, else: :long
+      get_in(zone_data, [format_key, :standard])
+    end
+  end
+
+  defp zone_standard_for_generic(_zone_data, _format, _type), do: nil
 
   # Look up the non-location name for a metazone. Returns `nil`
   # when the zone has no metazone mapping or the locale has no

--- a/test/localize/chars_datetime_test.exs
+++ b/test/localize/chars_datetime_test.exs
@@ -22,7 +22,7 @@ defmodule Localize.CharsDateTimeTest do
 
     test "honours the :format option" do
       assert Localize.Chars.to_string(@datetime, format: :long) ==
-               {:ok, "July 4, 2026, 11:30:15 AM GMT"}
+               {:ok, "July 4, 2026, 11:30:15 AM UTC"}
     end
 
     test "combines :locale and :format options" do

--- a/test/localize/date_test.exs
+++ b/test/localize/date_test.exs
@@ -335,4 +335,30 @@ defmodule Localize.DateTest do
                Localize.Date.to_string(~D[2017-07-10], locale: :en, format: :yMMMM)
     end
   end
+
+  describe "to_string/2 with a locale default numbering system" do
+    test "numeric date and time fields use the locale's default numbering system" do
+      assert {:ok, "१५ मार्च, २०२१"} =
+               Localize.Date.to_string(~D[2021-03-15], format: :long, locale: :mr)
+
+      assert {:ok, "३:००:०० AM"} =
+               Localize.Time.to_string(~T[03:00:00], format: :medium, locale: :mr)
+    end
+
+    test "a caller \"all\" override wins over the locale default" do
+      assert {:ok, "15 मार्च, 2021"} =
+               Localize.Date.to_string(~D[2021-03-15],
+                 format: :long,
+                 locale: :mr,
+                 number_system_overrides: %{"all" => :latn}
+               )
+    end
+
+    test "an \"all\" override reaches the time fields" do
+      assert {:ok, "०३:०९:०५"} =
+               Localize.DateTime.Formatter.format(~T[03:09:05], "HH:mm:ss", :en, %{
+                 number_system_overrides: %{"all" => :deva}
+               })
+    end
+  end
 end

--- a/test/localize/datetime/formatter_edge_test.exs
+++ b/test/localize/datetime/formatter_edge_test.exs
@@ -269,8 +269,8 @@ defmodule Localize.DateTime.FormatterEdgeTest do
 
   describe "timezone symbols on a UTC DateTime" do
     test "z widths render the specific non-location name" do
-      assert datetime_format(@utc_datetime, "z") == "GMT"
-      assert datetime_format(@utc_datetime, "zzzz") == "Greenwich Mean Time"
+      assert datetime_format(@utc_datetime, "z") == "UTC"
+      assert datetime_format(@utc_datetime, "zzzz") == "Coordinated Universal Time"
     end
 
     test "Z widths render basic, GMT, and extended ISO forms" do
@@ -290,8 +290,8 @@ defmodule Localize.DateTime.FormatterEdgeTest do
     end
 
     test "v widths render the generic non-location name" do
-      assert datetime_format(@utc_datetime, "v") == "GMT"
-      assert datetime_format(@utc_datetime, "vvvv") == "GMT"
+      assert datetime_format(@utc_datetime, "v") == "UTC"
+      assert datetime_format(@utc_datetime, "vvvv") == "Coordinated Universal Time"
     end
 
     test "V widths render zone id and location formats" do

--- a/test/localize/datetime/timezone_format_test.exs
+++ b/test/localize/datetime/timezone_format_test.exs
@@ -94,6 +94,24 @@ defmodule Localize.DateTime.TimezoneFormatTest do
       assert {:ok, name} = Timezone.non_location_format(@new_york_standard, :fr)
       assert name =~ "Est"
     end
+
+    test "zone-level names take precedence over the metazone" do
+      utc = %{time_zone: "Etc/UTC", utc_offset: 0, std_offset: 0}
+
+      assert {:ok, "Coordinated Universal Time"} = Timezone.non_location_format(utc, :en)
+      assert {:ok, "UTC"} = Timezone.non_location_format(utc, :en, format: :short)
+
+      assert {:ok, "Coordinated Universal Time"} =
+               Timezone.non_location_format(utc, :en, type: :generic)
+
+      assert {:ok, "UTC"} = Timezone.non_location_format(utc, :bg, format: :short)
+
+      london = %{time_zone: "Europe/London", utc_offset: 0, std_offset: 3600}
+      assert {:ok, "British Summer Time"} = Timezone.non_location_format(london, :en)
+
+      gmt = %{time_zone: "Etc/GMT", utc_offset: 0, std_offset: 0}
+      assert {:ok, "Greenwich Mean Time"} = Timezone.non_location_format(gmt, :en)
+    end
   end
 
   describe "gmt_format/3" do

--- a/test/localize/datetime/zone_symbol_test.exs
+++ b/test/localize/datetime/zone_symbol_test.exs
@@ -70,9 +70,9 @@ defmodule Localize.DateTime.ZoneSymbolTest do
       assert zone_format(@new_york_daylight, "zzzz") == "Eastern Daylight Time"
     end
 
-    test "UTC renders as GMT names" do
-      assert zone_format(@utc, "z") == "GMT"
-      assert zone_format(@utc, "zzzz") == "Greenwich Mean Time"
+    test "UTC renders its zone-level names" do
+      assert zone_format(@utc, "z") == "UTC"
+      assert zone_format(@utc, "zzzz") == "Coordinated Universal Time"
     end
 
     test "zone with a long metazone name but no short one falls back to GMT format" do

--- a/test/localize/message/interpreter_coverage_test.exs
+++ b/test/localize/message/interpreter_coverage_test.exs
@@ -170,7 +170,7 @@ defmodule Localize.Message.InterpreterCoverageTest do
     end
 
     test "time style full formats a DateTime through the time function" do
-      assert {:ok, ["10:30:00 AM Greenwich Mean Time"], ["t"], []} =
+      assert {:ok, ["10:30:00 AM Coordinated Universal Time"], ["t"], []} =
                format("{$t :time style=full}", %{"t" => ~U[2024-01-01 10:30:00Z]}, locale: :en)
     end
 

--- a/test/localize/time_test.exs
+++ b/test/localize/time_test.exs
@@ -370,7 +370,7 @@ defmodule Localize.TimeTest do
       {:ok, out} =
         Localize.DateTime.to_string(~U[2026-01-01 21:00:00Z], format: :long, locale: :de)
 
-      assert out =~ "GMT"
+      assert out =~ "UTC"
       refute String.ends_with?(out, " ")
     end
 

--- a/test/support/parse_test_data.ex
+++ b/test/support/parse_test_data.ex
@@ -123,8 +123,14 @@ defmodule Localize.DateTime.TestData do
     {:ok, datetime, _} = DateTime.from_iso8601(datetime)
 
     case DateTime.shift_zone(datetime, timezone) do
-      {:ok, shifted} -> shifted
-      {:error, _} -> datetime
+      {:ok, shifted} ->
+        shifted
+
+      {:error, _} when timezone == "Etc/GMT" ->
+        %{datetime | time_zone: "Etc/GMT", zone_abbr: "GMT"}
+
+      {:error, _} ->
+        datetime
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -43,6 +43,7 @@ test_locales = [
   "ja-JP",
   "ko",
   "ky",
+  "mr",
   "nl-BE",
   "pt",
   "pt-AO",


### PR DESCRIPTION
Two fixes, found by output-diffing a migration from ex_cldr. Both restore parity with ICU/Intl and ex_cldr.

Commit 1: `Localize.DateTime.to_string!(~U[2021-03-15 03:00:00Z], format: :long, locale: :en)` ends in `"GMT"`; ICU and ex_cldr render `"UTC"` ([ex_cldr doctest](https://github.com/elixir-cldr/cldr_dates_times/blob/v2.25.6/lib/cldr/format/date_time_timezone.ex#L168-L173)). Per [TR35 step 4](https://unicode.org/reports/tr35/tr35-dates.html#Using_Time_Zone_Names), zone-level names precede metazone names — `non_location_format/3` never read them (Etc/UTC, Europe/London and Europe/Dublin carry them; London summer rendered `"GMT+01:00"` instead of `"British Summer Time"`). Includes a harness fix: the conformance `[Etc/GMT]` inputs silently degraded to `Etc/UTC` because `DateTime.shift_zone/2` fails on the UTC-only database — that's what made GMT names look expected for UTC.

Commit 2: `Localize.Date.to_string!(~D[2021-03-15], format: :long, locale: :mr)` rendered `"15 मार्च, 2021"`; ICU and ex_cldr render `"१५ मार्च, २०२१"` (mr defaults to deva; likewise my, bn, fa). The formatter now merges the locale's default numbering system as the `"all"` override — pattern `numbers=` and caller overrides keep precedence — and applies overrides to all numeric fields, not just y/M/d. `r` stays latn per TR35.
